### PR TITLE
[#67] 회원가입용 response api와 mock api작성

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,29 +1,24 @@
 import { http, HttpResponse } from "msw";
 import successForAndPrintResponseBody from "./samples/successForAndPrintResponseBody.json";
-import successIfAndElseResponseBody from "./samples/successIfAndElseResponseBody.json";
-import successAssignResponseBody from "./samples/successAssignResponseBody.json";
-// export const handlers = [
-//   http.post("/v1/python", () => {
-//     return HttpResponse.json([{ code: "test" }]);
-//   }),
-// ];
-
-// for, print 데이터 테스트
+interface SignupUser {
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
 export const handlers = [
   http.post("/v1/python", () => {
     return HttpResponse.json(successForAndPrintResponseBody);
   }),
+  http.post("/signup", async ({ request }) => {
+    const { username } = (await request.json()) as SignupUser;
+    if (username === "error") return HttpResponse.json({ message: "error" }, { status: 500 });
+    return HttpResponse.json(
+      {
+        success: true,
+        message: "로그인 성공",
+      },
+      { status: 200 }
+    );
+  }),
 ];
-
-// if, elif, else 데이터 테스트
-// export const handlers = [
-//     http.post('/v1/python', () => {
-//         return HttpResponse.json(successIfAndElseResponseBody);
-//     }),
-// ];
-
-// export const handlers = [
-//   http.post("/v1/python", () => {
-//     return HttpResponse.json(successAssignResponseBody);
-//   }),
-// ];

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -1,5 +1,7 @@
 import { useState, ChangeEvent, FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
 import styles from "./Signup.module.css";
+import axios from "axios";
 
 interface FormData {
   username: string;
@@ -42,11 +44,26 @@ const Signup = () => {
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
-
+  const mutation = useMutation({
+    mutationFn: async (formData: FormData) => {
+      return axios.post("http://localhost:8000/signup", formData, {
+        headers: { "Content-Type": "application/json" },
+        withCredentials: true,
+      });
+    },
+    onSuccess() {
+      alert("회원가입이 완료되었습니다.");
+      // 랜딩 페이지로 접근하는 코드가 들어가야 할 곳
+    },
+    onError(error) {
+      console.error("회원가입 에러", error);
+      alert("회원가입 중 오류가 발생했습니다.");
+    },
+  });
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (validateForm()) {
-      // 회원가입 API 호출해야하는 부분
+      mutation.mutate(formData);
     }
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #67 

## 📝 작업 내용

- 회원가입용 api와 그걸 테스트하기위한 mock api작성
- 
![image](https://github.com/user-attachments/assets/4337130a-d617-4667-ac61-3fe7d4df5ac2)
회원가입이 성공하면 이렇게 성공했다는 alert문이 뜨게 작성
나중에는 렌딩 페이지 혹은 로그인 페이지로 바로 가게 변경 예정

![image](https://github.com/user-attachments/assets/753146be-d848-4c16-bcd4-4621b28cf475)
지금은 사용자 이름이 error이면 에러가 나게 설정했습니다 이 에러는 나중에 중복아이디나 사용할 수 없는 닉네임에 이메일에 대한 처리가 될 것 같습니다


